### PR TITLE
YAML format change

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -18,7 +18,7 @@ jobs:
             exit 1
           fi
           if python watt.py -e cromwell-84.jar -w extract_stat -t mismatch; then
-            echo "Test mismatch for workflow extract_sts succeeded which should not have passed."
+            echo "Test mismatch for workflow extract_stat succeeded which should not have passed."
             exit 1
           fi
           if python watt.py -e cromwell-84.jar -w extract_stat -t array_shape_mismatch; then

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -10,7 +10,7 @@ jobs:
           python watt.py -e cromwell-84.jar -t simple compress_file expect_fail -p $(nproc)
           echo "THE FOLLOWING TESTS SHOULD ALL FAIL"
           if python watt.py -e cromwell-84.jar -w say_hello -t mismatch; then
-            echo "Teat mismatch for workflow say_hello succeeded which should not have passed."
+            echo "Test mismatch for workflow say_hello succeeded which should not have passed."
             exit 1
           fi
           if python watt.py -e cromwell-84.jar -w say_hello -t file_type_mismatch; then

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -6,7 +6,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           pip install -r requirements.txt
-          wget https://github.com/broadinstitute/cromwell/releases/download/84/cromwell-84.jar
+          wget -q https://github.com/broadinstitute/cromwell/releases/download/84/cromwell-84.jar
           python watt.py -e cromwell-84.jar -t simple compress_file expect_fail -p $(nproc)
           echo "THE FOLLOWING TESTS SHOULD ALL FAIL"
           if python watt.py -e cromwell-84.jar -w say_hello -t mismatch; then

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -10,22 +10,22 @@ jobs:
           python watt.py -e cromwell-84.jar -t simple compress_file expect_fail -p $(nproc)
           echo "THE FOLLOWING TESTS SHOULD ALL FAIL"
           if python watt.py -e cromwell-84.jar -w say_hello -t mismatch; then
-            echo "A test succeeded which should have passed.  Please look above for an unexpected success"
+            echo "Teat mismatch for workflow say_hello succeeded which should not have passed."
             exit 1
           fi
           if python watt.py -e cromwell-84.jar -w say_hello -t file_type_mismatch; then
-            echo "A test succeeded which should have passed.  Please look above for an unexpected success"
+            echo "Test file_type_mismatch for workflow say_hello succeeded which should not have passed."
             exit 1
           fi
           if python watt.py -e cromwell-84.jar -w extract_stat -t mismatch; then
-            echo "A test succeeded which should have passed.  Please look above for an unexpected success"
+            echo "Test mismatch for workflow extract_sts succeeded which should not have passed."
             exit 1
           fi
           if python watt.py -e cromwell-84.jar -w extract_stat -t array_shape_mismatch; then
-            echo "A test succeeded which should have passed.  Please look above for an unexpected success"
+            echo "Test array_shape_mismatch for workflow extract_stat succeeded which should not have passed."
             exit 1
           fi
           if python watt.py -e cromwell-84.jar -w bad_workflow; then
-            echo "A test succeeded which should have passed.  Please look above for an unexpected success"
+            echo "Test for workflow bad_workflow succeeded which should not have passed."
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ The configuration file controls how Watt accesses the WDL scripts along with the
 
 The file uses `yaml` format, with each top-level entry corresponding to a different test. An example test might be recorded as:
 ``` 
-my_watt_test:
-  workflow_name: "Workflow"
-  test_name: "MyTest"
+workflow_name:
   path: "/workflows/something.wdl"
-  test_inputs: "/tests/inputs.json"
-  expected_outputs: "/tests/outputs.json"
+  tests:
+    test_name:
+      test_inputs: "/tests/inputs.json"
+      expected_outputs: "/tests/outputs.json"
 ```
-The pair `(workflow_name, test_name)` should be unique across all tests, but either of them can be repeated, i.e. you can have multiple different tests for the same workflow, or repeat the name of a test across different workflows. These fields can be used separately or together to filter which tests you'd like to run when invoking Watt. See below for details.
+The workflow_name and test_name can be used separately or together to filter which tests you'd like to run when invoking Watt. See below for details.
 
 The `path` points to the WDL to be run for the test, and the `test_inputs` are given to Cromwell to configure that run. The `expected_outputs` is what should match the Cromwell outputs JSON. You can set this field to `null` in the configuration to mean you expect the Cromwell job to fail for the given inputs to check e.g. error handling or edge cases in your workflow. 
 You can set an output in the `expected_outputs` json to `null` tell Watt not to compare that output.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyyaml==6.0.1
+ruamel.yaml==0.18.6
 multiprocess==0.70.16

--- a/watt_config.yml
+++ b/watt_config.yml
@@ -1,54 +1,33 @@
-say_hello_simple:
-  workflow_name: "say_hello"
-  test_name: "simple"
+say_hello:
   path: "/workflows/say_hello.wdl"
-  test_inputs: "/tests/say_hello/simple_test/test_inputs.json"
-  expected_outputs: "/tests/say_hello/simple_test/expected_outputs.json"
-say_hello_mistake:
-  workflow_name: "say_hello"
-  test_name: "mismatch"
-  path: "/workflows/say_hello.wdl"
-  test_inputs: "/tests/say_hello/mismatch_test/test_inputs.json"
-  expected_outputs: "/tests/say_hello/mismatch_test/expected_outputs.json"
-say_hello_file_type_mismatch:
-  workflow_name: "say_hello"
-  test_name: "file_type_mismatch"
-  path: "/workflows/say_hello.wdl"
-  test_inputs: "/tests/say_hello/file_type_mismatch_test/test_inputs.json"
-  expected_outputs: "/tests/say_hello/file_type_mismatch_test/expected_outputs.json"
-say_hello_compress_file:
-  workflow_name: "say_hello"
-  test_name: "compress_file"
-  path: "/workflows/say_hello.wdl"
-  test_inputs: "/tests/say_hello/compress_file_test/test_inputs.json"
-  expected_outputs: "/tests/say_hello/compress_file_test/expected_outputs.json"
-extract_stat_simple:
-  workflow_name: "extract_stat"
-  test_name: "simple"
+  tests:
+    simple:
+      test_inputs: "/tests/say_hello/simple_test/test_inputs.json"
+      expected_outputs: "/tests/say_hello/simple_test/expected_outputs.json"
+    mismatch:
+      test_inputs: "/tests/say_hello/mismatch_test/test_inputs.json"
+      expected_outputs: "/tests/say_hello/mismatch_test/expected_outputs.json"
+    file_type_mismatch:
+      test_inputs: "/tests/say_hello/file_type_mismatch_test/test_inputs.json"
+      expected_outputs: "/tests/say_hello/file_type_mismatch_test/expected_outputs.json"
+    compress_file:
+      test_inputs: "/tests/say_hello/compress_file_test/test_inputs.json"
+      expected_outputs: "/tests/say_hello/compress_file_test/expected_outputs.json"
+extract_stat:
   path: "/workflows/extract_stat.wdl"
-  test_inputs: "/tests/extract_stat/simple_test/test_inputs.json"
-  expected_outputs: "/tests/extract_stat/simple_test/expected_outputs.json"
-extract_stat_mismatch:
-  workflow_name: "extract_stat"
-  test_name: "mismatch"
-  path: "/workflows/extract_stat.wdl"
-  test_inputs: "/tests/extract_stat/mismatch_test/test_inputs.json"
-  expected_outputs: "/tests/extract_stat/mismatch_test/expected_outputs.json"
-extract_stat_expect_fail:
-  workflow_name: "extract_stat"
-  test_name: "expect_fail"
-  path: "/workflows/extract_stat.wdl"
-  test_inputs: "/tests/extract_stat/expect_fail_test/test_inputs.json"
-  expected_outputs: null
-extract_stat_array_shape_mismatch:
-  workflow_name: "extract_stat"
-  test_name: "array_shape_mismatch"
-  path: "/workflows/extract_stat.wdl"
-  test_inputs: "/tests/extract_stat/array_shape_mismatch_test/test_inputs.json"
-  expected_outputs: "/tests/extract_stat/array_shape_mismatch_test/expected_outputs.json"
+  tests:
+    simple:
+      test_inputs: "/tests/extract_stat/simple_test/test_inputs.json"
+      expected_outputs: "/tests/extract_stat/simple_test/expected_outputs.json"
+    expect_fail:
+      test_inputs: "/tests/extract_stat/expect_fail_test/test_inputs.json"
+      expected_outputs: null
+    array_shape_mismatch:
+      test_inputs: "/tests/extract_stat/array_shape_mismatch_test/test_inputs.json"
+      expected_outputs: "/tests/extract_stat/array_shape_mismatch_test/expected_outputs.json"
 bad_workflow:
-  workflow_name: "bad_workflow"
-  test_name: "bad_workflow"
   path: "/workflows/bad_workflow.wdl"
-  test_inputs: "/tests/bad_workflow/test_inputs.json"
-  expected_outputs: "/tests/bad_workflow/expected_outputs.json"
+  tests:
+    bad_workflow:
+      test_inputs: "/tests/bad_workflow/test_inputs.json"
+      expected_outputs: "/tests/bad_workflow/expected_outputs.json"

--- a/watt_config.yml
+++ b/watt_config.yml
@@ -25,6 +25,9 @@ extract_stat:
     array_shape_mismatch:
       test_inputs: "/tests/extract_stat/array_shape_mismatch_test/test_inputs.json"
       expected_outputs: "/tests/extract_stat/array_shape_mismatch_test/expected_outputs.json"
+    mismatch:
+      test_inputs: "/tests/extract_stat/mismatch_test/test_inputs.json"
+      expected_outputs: "/tests/extract_stat/mismatch_test/expected_outputs.json"
 bad_workflow:
   path: "/workflows/bad_workflow.wdl"
   tests:


### PR DESCRIPTION
Changed YAML format, as discussed in https://github.com/broadinstitute/palantir-workflows/pull/176#discussion_r1620768945

Also changed to use ruamel.yaml for yaml parsing so that duplicate keys will not be allowed (PyYAML overwrites duplicate keys with the last specified value)